### PR TITLE
fix edition formatting and add alt link

### DIFF
--- a/bookwyrm/templates/rss/edition.html
+++ b/bookwyrm/templates/rss/edition.html
@@ -1,11 +1,10 @@
 {% load i18n %}
-{% blocktrans trimmed with book_title=obj.title book_author=obj.author_text %}
-‘{{ book_title }}’{% if book_author %} by {{ book_author }}{% endif %}
-{% endblocktrans %}
-{{obj.description|default:""}}
-{% if obj.isbn_13 %}{% trans "ISBN 13:" %} {{ obj.isbn_13 }}{% endif %}
-{% if obj.oclc_number %}{% trans "OCLC Number:" %} {{ obj.oclc_number }}{% endif %}
-{% if obj.asin %}{% trans "ASIN:" %} {{ obj.asin }}{% endif %}
-{% if obj.aasin %}{% trans "Audible ASIN:" %} {{ obj.aasin }}{% endif %}
-{% if obj.isfdb %}{% trans "ISFDB ID:" %} {{ obj.isfdb }}{% endif %}
+{% load shelf_tags %}
+‘{{ obj.title }}’ {% if obj.author_text %} by {{obj.author_text}} {% endif %}
+<p>{{ obj.description|default_if_none:obj.parent_work.description}}</p>
+{% if obj.isbn_13 %}{% trans "ISBN 13:" %} {{ obj.isbn_13 }}<br>{% endif %}
+{% if obj.oclc_number %}{% trans "OCLC Number:" %} {{ obj.oclc_number }}<br>{% endif %}
+{% if obj.asin %}{% trans "ASIN:" %} {{ obj.asin }}<br>{% endif %}
+{% if obj.aasin %}{% trans "Audible ASIN:" %} {{ obj.aasin }}<br>{% endif %}
+{% if obj.isfdb %}{% trans "ISFDB ID:" %} {{ obj.isfdb }}<br>{% endif %}
 {% if obj.goodreads_key %}{% trans "Goodreads:" %} {{ obj.goodreads_key }}{% endif %}

--- a/bookwyrm/templates/shelf/shelf.html
+++ b/bookwyrm/templates/shelf/shelf.html
@@ -12,6 +12,11 @@
     {% include 'snippets/opengraph.html' with image=user.preview_image %}
 {% endblock %}
 
+
+{% block head_links %}
+    <link rel="alternate" type="application/rss+xml" href="{{ request.get_full_path }}/rss" title="{{ user.display_name }} - {{ shelf.name }}" />
+{% endblock %}
+
 {% block content %}
 <header class="block">
     <h1 class="title">


### PR DESCRIPTION
Template blocks can't have logic or other blocks inside them.

This commit fixes the problem with the Edition template by removing the `blocktrans` block: original titles and descriptions shouldn't be translated, and this also makes the template simpler and avoids the logic-in-blocks problem.

Additionally if an edition is lacking a description, we fall back to the parent_work description, and line breaks have been added where needed.

Also adds a `rel="alternate"` link to shelf pages to aid feed auto-discovery